### PR TITLE
Implement path basename and suffix helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CFLAGS=-std=c23 -g -Wall -Wextra -Wunused-result
-SRC_DIR=src
+CFLAGS=-std=c2x -g -Wall -Wextra -Wunused-result
+SRC_DIR=dev
 TESTS_DIR=tests
 
 PROJ_DIR=${shell pwd}
@@ -16,7 +16,8 @@ ${BIN_DIR}:
 sandwich = $(addprefix $1,$(addsuffix $3,$2))
 
 ## objs NAMES...
-objs = $(sort $(call sandwich,${OBJ_DIR}/,$1,.o))
+# Only include objects for modules that have corresponding source files
+objs = $(sort $(foreach m,$1,$(if $(wildcard ${SRC_DIR}/$(m).c),${OBJ_DIR}/$(m).o)))
 
 ## deps NAMES...
 deps = $(sort $(foreach thing,$1,${$(thing)_deps}))
@@ -44,8 +45,8 @@ $(eval $(call PROGRAM_build,tests))
 ${OBJ_DIR}/%.o: ${SRC_DIR}/%.c ${SRC_DIR}/%.h | ${OBJ_DIR}
 	cc ${CFLAGS} $< -c -o $@
 
-${BIN_DIR}/test_%: ${TESTS_DIR}/%.c build_% build_deps_for_tests | ${BIN_DIR}
-	cc ${CFLAGS} $< $(call objs,$* $(call deps,$* tests)) -o $@
+${BIN_DIR}/test_%: ${TESTS_DIR}/%.c $(call objs,$(call deps,$* tests)) | ${BIN_DIR}
+	cc ${CFLAGS} $< $(call objs,$(call deps,$* tests)) -o $@
 
 test_%: ${BIN_DIR}/test_% ; $<
 

--- a/dev/path.h
+++ b/dev/path.h
@@ -93,9 +93,9 @@ Path allc_path_to_absolute_path(Path self);
 
 Path allc_path_to_dirname_path(Path self);
 
-StrBuf allc_path_to_basename_strbuf(Path self); // TODO
+StrBuf allc_path_to_basename_strbuf(Path self);
 
-StrBuf allc_path_to_suffix_strbuf(Path self); // TODO
+StrBuf allc_path_to_suffix_strbuf(Path self);
 
 // Path - Boolean Statements {{{2
 // ------------------------------
@@ -127,6 +127,7 @@ size_t allc_path_count_parts(Path *self);
 #include <errno.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 // Macros {{{1
@@ -319,9 +320,54 @@ Path allc_path_to_dirname_path(Path self)
 
         size_t i = allc_cstr_find_cstr(self->buf, -1, ALLC_PATH_SEP);
         allc_cstr_shift_left(self->buf + i, self->length - i);
+
         self->length = i;
         return self;
     }
+}
+
+StrBuf allc_path_to_basename_strbuf(Path self)
+{
+    char sep = ALLC_PATH_SEP[0];
+    size_t end = self->length;
+    while (0 < end && self->buf[end - 1] == sep)
+    {
+        end -= 1;
+    }
+    size_t start = end;
+    while (0 < start && self->buf[start - 1] != sep)
+    {
+        start -= 1;
+    }
+    size_t len = end - start;
+    StrBuf result = allc_strbuf_new(self->allocator, len + 1);
+    memcpy(result->buf, self->buf + start, len);
+    result->buf[len] = '\0';
+    result->length = len;
+    return result;
+}
+
+StrBuf allc_path_to_suffix_strbuf(Path self)
+{
+    StrBuf base = allc_path_to_basename_strbuf(self);
+    size_t idx = allc_cstr_find_char(base->buf, -1, '.');
+    StrBuf result;
+    if (idx == base->length || idx == 0)
+    {
+        result = allc_strbuf_new(base->allocator, 1);
+        result->buf[0] = '\0';
+        result->length = 0;
+    }
+    else
+    {
+        size_t len = base->length - idx - 1;
+        result = allc_strbuf_new(base->allocator, len + 1);
+        memcpy(result->buf, base->buf + idx + 1, len);
+        result->buf[len] = '\0';
+        result->length = len;
+    }
+    allc_strbuf_delete(base);
+    return result;
 }
 
 // Path - Boolean Statements {{{2

--- a/tests/cstr.c
+++ b/tests/cstr.c
@@ -1,5 +1,5 @@
-#include "../src/macro.h"
-#include "../src/cstr.h"
+#include "../dev/macro.h"
+#include "../dev/cstr.h"
 
 void allc_cstr_capitalize(char *str);
 void allc_cstr_capitalize_all(char *str);

--- a/tests/list.c
+++ b/tests/list.c
@@ -1,5 +1,5 @@
 
-#include "../src/list.h"
+#include "../dev/list.h"
 #include <stdio.h>
 
 #define PRINT_INFO(list) printf("\n>length=%lu\n\n", (list)->length)

--- a/tests/path.c
+++ b/tests/path.c
@@ -1,7 +1,7 @@
 #define ALLC_PATH__IMPL
 
-#include "../src/path.h"
-#include "../src/macro.h"
+#include "../dev/path.h"
+#include "../dev/macro.h"
 
 void test__new(allc_allocator_t allocator)
 {
@@ -222,6 +222,54 @@ void test__allc_path_extend_path(allc_allocator_t allocator)
   allc_path_delete(p2);
 }
 
+void test__allc_path_to_basename_strbuf(allc_allocator_t allocator)
+{
+  printf("\n[%s]\n", __func__);
+
+  Path p = allc_path_new(allocator);
+
+  allc_path_set_cstr(&p, "/home/user/file.txt");
+  StrBuf base = allc_path_to_basename_strbuf(p);
+  ALLC_TEST_ANY("file.txt", "%s", base->buf);
+  allc_strbuf_delete(base);
+
+  allc_path_set_cstr(&p, "/home/user/");
+  base = allc_path_to_basename_strbuf(p);
+  ALLC_TEST_ANY("user", "%s", base->buf);
+  allc_strbuf_delete(base);
+
+  allc_path_set_cstr(&p, "plainname");
+  base = allc_path_to_basename_strbuf(p);
+  ALLC_TEST_ANY("plainname", "%s", base->buf);
+  allc_strbuf_delete(base);
+
+  allc_path_delete(p);
+}
+
+void test__allc_path_to_suffix_strbuf(allc_allocator_t allocator)
+{
+  printf("\n[%s]\n", __func__);
+
+  Path p = allc_path_new(allocator);
+
+  allc_path_set_cstr(&p, "/tmp/archive.tar.gz");
+  StrBuf suf = allc_path_to_suffix_strbuf(p);
+  ALLC_TEST_ANY("gz", "%s", suf->buf);
+  allc_strbuf_delete(suf);
+
+  allc_path_set_cstr(&p, "noext");
+  suf = allc_path_to_suffix_strbuf(p);
+  ALLC_TEST_ANY("", "%s", suf->buf);
+  allc_strbuf_delete(suf);
+
+  allc_path_set_cstr(&p, ".hidden");
+  suf = allc_path_to_suffix_strbuf(p);
+  ALLC_TEST_ANY("", "%s", suf->buf);
+  allc_strbuf_delete(suf);
+
+  allc_path_delete(p);
+}
+
 void test__allc_path_to_absolute_path(allc_allocator_t allocator) {
     printf("\n[%s]\n", __func__);
 
@@ -259,5 +307,7 @@ int main()
   test__allc_path_count_parts(allocator);
   test__allc_path_to_dirname_path(allocator);
   test__allc_path_extend_path(allocator);
+  test__allc_path_to_basename_strbuf(allocator);
+  test__allc_path_to_suffix_strbuf(allocator);
   test__allc_path_to_absolute_path(allocator);
 }

--- a/tests/strbuf.c
+++ b/tests/strbuf.c
@@ -1,5 +1,5 @@
-#include "../src/strbuf.h"
-#include "../src/macro.h"
+#include "../dev/strbuf.h"
+#include "../dev/macro.h"
 
 void test__allc_strbuf_is_equal(allc_allocator_t allocator) {
     printf("\n[%s]\n", __func__);


### PR DESCRIPTION
## Summary
- implement `allc_path_to_basename_strbuf` and `allc_path_to_suffix_strbuf`
- include `<string.h>` for path implementation
- add unit tests for new helpers
- adjust Makefile to build from `dev/` and detect header-only modules
- update unit tests to include headers from `dev`

## Testing
- `make test_path` *(fails to compile path tests)*
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_685c6f5c048c8329abc2bc29f462d1a8